### PR TITLE
Refactor relation aliases work

### DIFF
--- a/src/jetquery.zig
+++ b/src/jetquery.zig
@@ -266,7 +266,7 @@ test "order by with relations (short-hand)" {
         .orderBy(.{ .cat = .name });
 
     try std.testing.expectEqualStrings(
-        \\SELECT "humans"."id", "humans"."cat_id", "humans"."name" FROM "humans" INNER JOIN "cats" ON "humans"."cat_id" = "cats"."id" WHERE (1 = 1) ORDER BY "cats"."name" ASC
+        \\SELECT "humans"."id", "humans"."cat_id", "humans"."name" FROM "humans" INNER JOIN "cats" AS "cat" ON "humans"."cat_id" = "cat"."id" WHERE (1 = 1) ORDER BY "cat"."name" ASC
     ,
         query.sql,
     );
@@ -295,7 +295,7 @@ test "order by with relations (explicit form)" {
         .orderBy(.{ .cat = .{ .name = .descending } });
 
     try std.testing.expectEqualStrings(
-        \\SELECT "humans"."id", "humans"."cat_id", "humans"."name" FROM "humans" INNER JOIN "cats" ON "humans"."cat_id" = "cats"."id" WHERE (1 = 1) ORDER BY "cats"."name" DESC
+        \\SELECT "humans"."id", "humans"."cat_id", "humans"."name" FROM "humans" INNER JOIN "cats" AS "cat" ON "humans"."cat_id" = "cat"."id" WHERE (1 = 1) ORDER BY "cat"."name" DESC
     ,
         query.sql,
     );
@@ -345,7 +345,7 @@ test "order by with relations and base table, short + explicit forms and synthet
     });
 
     try std.testing.expectEqualStrings(
-        \\SELECT "humans"."id", "humans"."cat_id", "humans"."family_id", "humans"."name" FROM "humans" INNER JOIN "cats" ON "humans"."cat_id" = "cats"."id" INNER JOIN "families" ON "humans"."family_id" = "families"."id" WHERE (1 = 1) ORDER BY "humans"."id" DESC, "cats"."name" DESC, MAX("cats"."paws") ASC, MIN("cats"."age") DESC, "families"."id" ASC, "families"."name" ASC, MAX("families"."wealth") ASC
+        \\SELECT "humans"."id", "humans"."cat_id", "humans"."family_id", "humans"."name" FROM "humans" INNER JOIN "cats" AS "cat" ON "humans"."cat_id" = "cat"."id" INNER JOIN "families" AS "family" ON "humans"."family_id" = "family"."id" WHERE (1 = 1) ORDER BY "humans"."id" DESC, "cat"."name" DESC, MAX("cat"."paws") ASC, MIN("cat"."age") DESC, "family"."id" ASC, "family"."name" ASC, MAX("family"."wealth") ASC
     ,
         query.sql,
     );
@@ -561,7 +561,7 @@ test "nested distinct().count()" {
     const query = Query(TestAdapter, Schema, .Human).include(.cat, .{}).where(.{ .name = "Bob" }).distinct(.{ .name, .{ .cat = .{.name} } }).count();
 
     try std.testing.expectEqualStrings(
-        \\SELECT COUNT(DISTINCT("humans"."name", "cats"."name")) FROM "humans" INNER JOIN "cats" ON "humans"."cat_id" = "cats"."id" WHERE "humans"."name" = $1
+        \\SELECT COUNT(DISTINCT("humans"."name", "cat"."name")) FROM "humans" INNER JOIN "cats" AS "cat" ON "humans"."cat_id" = "cat"."id" WHERE "humans"."name" = $1
     , query.sql);
     try std.testing.expect(query.isValid());
 }
@@ -780,7 +780,7 @@ test "belongsTo" {
         .findBy(.{ .name = "Bob" });
 
     try std.testing.expectEqualStrings(
-        \\SELECT "humans"."id", "humans"."cat_id", "humans"."name", "cats"."id", "cats"."name", "cats"."paws", "cats"."created_at", "cats"."updated_at" FROM "humans" INNER JOIN "cats" ON "humans"."cat_id" = "cats"."id" WHERE "humans"."name" = $1 ORDER BY "humans"."id" ASC LIMIT $2
+        \\SELECT "humans"."id", "humans"."cat_id", "humans"."name", "cat"."id", "cat"."name", "cat"."paws", "cat"."created_at", "cat"."updated_at" FROM "humans" INNER JOIN "cats" AS "cat" ON "humans"."cat_id" = "cat"."id" WHERE "humans"."name" = $1 ORDER BY "humans"."id" ASC LIMIT $2
     ,
         query.sql,
     );
@@ -821,7 +821,7 @@ test "belongsTo (multiple)" {
         .findBy(.{ .name = "Bob" });
 
     try std.testing.expectEqualStrings(
-        \\SELECT "humans"."id", "humans"."family_id", "humans"."cat_id", "humans"."name", "cats"."id", "cats"."name", "cats"."paws", "cats"."created_at", "cats"."updated_at", "families"."id", "families"."name" FROM "humans" INNER JOIN "cats" ON "humans"."cat_id" = "cats"."id" INNER JOIN "families" ON "humans"."family_id" = "families"."id" WHERE "humans"."name" = $1 ORDER BY "humans"."id" ASC LIMIT $2
+        \\SELECT "humans"."id", "humans"."family_id", "humans"."cat_id", "humans"."name", "cat"."id", "cat"."name", "cat"."paws", "cat"."created_at", "cat"."updated_at", "family"."id", "family"."name" FROM "humans" INNER JOIN "cats" AS "cat" ON "humans"."cat_id" = "cat"."id" INNER JOIN "families" AS "family" ON "humans"."family_id" = "family"."id" WHERE "humans"."name" = $1 ORDER BY "humans"."id" ASC LIMIT $2
     ,
         query.sql,
     );
@@ -863,7 +863,7 @@ test "belongsTo (with specified columns)" {
         .findBy(.{ .name = "Bob" });
 
     try std.testing.expectEqualStrings(
-        \\SELECT "humans"."name", "cats"."name", "cats"."paws", "families"."name" FROM "humans" INNER JOIN "cats" ON "humans"."cat_id" = "cats"."id" INNER JOIN "families" ON "humans"."family_id" = "families"."id" WHERE "humans"."name" = $1 ORDER BY "humans"."id" ASC LIMIT $2
+        \\SELECT "humans"."name", "cat"."name", "cat"."paws", "family"."name" FROM "humans" INNER JOIN "cats" AS "cat" ON "humans"."cat_id" = "cat"."id" INNER JOIN "families" AS "family" ON "humans"."family_id" = "family"."id" WHERE "humans"."name" = $1 ORDER BY "humans"."id" ASC LIMIT $2
     ,
         query.sql,
     );
@@ -944,7 +944,7 @@ test "nested where" {
     });
 
     try std.testing.expectEqualStrings(
-        \\SELECT "humans"."id", "humans"."family_id", "humans"."cat_id", "humans"."name", "cats"."id", "cats"."name", "cats"."paws", "cats"."created_at", "cats"."updated_at", "families"."id", "families"."name" FROM "humans" INNER JOIN "cats" ON "humans"."cat_id" = "cats"."id" INNER JOIN "families" ON "humans"."family_id" = "families"."id" WHERE ("humans"."name" = $1 AND "cats"."name" = $2 AND "families"."name" = $3) ORDER BY "humans"."id" ASC
+        \\SELECT "humans"."id", "humans"."family_id", "humans"."cat_id", "humans"."name", "cat"."id", "cat"."name", "cat"."paws", "cat"."created_at", "cat"."updated_at", "family"."id", "family"."name" FROM "humans" INNER JOIN "cats" AS "cat" ON "humans"."cat_id" = "cat"."id" INNER JOIN "families" AS "family" ON "humans"."family_id" = "family"."id" WHERE ("humans"."name" = $1 AND "cat"."name" = $2 AND "family"."name" = $3) ORDER BY "humans"."id" ASC
     ,
         query.sql,
     );
@@ -993,7 +993,7 @@ test "operator logic" {
     });
 
     try std.testing.expectEqualStrings(
-        \\SELECT "humans"."id", "humans"."family_id", "humans"."cat_id", "humans"."name", "cats"."id", "cats"."name", "cats"."paws", "cats"."created_at", "cats"."updated_at", "families"."id", "families"."name" FROM "humans" INNER JOIN "cats" ON "humans"."cat_id" = "cats"."id" INNER JOIN "families" ON "humans"."family_id" = "families"."id" WHERE ("humans"."name" = $1 OR "humans"."name" = $2 OR "cats"."name" = $3 AND NOT "families"."name" = $4) ORDER BY "humans"."id" ASC
+        \\SELECT "humans"."id", "humans"."family_id", "humans"."cat_id", "humans"."name", "cat"."id", "cat"."name", "cat"."paws", "cat"."created_at", "cat"."updated_at", "family"."id", "family"."name" FROM "humans" INNER JOIN "cats" AS "cat" ON "humans"."cat_id" = "cat"."id" INNER JOIN "families" AS "family" ON "humans"."family_id" = "family"."id" WHERE ("humans"."name" = $1 OR "humans"."name" = $2 OR "cat"."name" = $3 AND NOT "family"."name" = $4) ORDER BY "humans"."id" ASC
     ,
         query.sql,
     );
@@ -1270,7 +1270,7 @@ test "inner join" {
         .join(.inner, .computers)
         .select(.{.name});
     try std.testing.expectEqualStrings(
-        \\SELECT "humans"."name" FROM "humans" INNER JOIN "cats" ON "humans"."cat_id" = "cats"."id" INNER JOIN "computers" ON "humans"."id" = "computers"."human_id" WHERE (1 = 1) ORDER BY "humans"."id" ASC
+        \\SELECT "humans"."name" FROM "humans" INNER JOIN "cats" AS "cat" ON "humans"."cat_id" = "cat"."id" INNER JOIN "computers" AS "computers" ON "humans"."id" = "computers"."human_id" WHERE (1 = 1) ORDER BY "humans"."id" ASC
     , query.sql);
     try std.testing.expect(query.isValid());
 }
@@ -1309,7 +1309,7 @@ test "outer join" {
         .join(.outer, .computers)
         .select(.{.name});
     try std.testing.expectEqualStrings(
-        \\SELECT "humans"."name" FROM "humans" LEFT OUTER JOIN "cats" ON "humans"."cat_id" = "cats"."id" LEFT OUTER JOIN "computers" ON "humans"."id" = "computers"."human_id" WHERE (1 = 1) ORDER BY "humans"."id" ASC
+        \\SELECT "humans"."name" FROM "humans" LEFT OUTER JOIN "cats" AS "cat" ON "humans"."cat_id" = "cat"."id" LEFT OUTER JOIN "computers" AS "computers" ON "humans"."id" = "computers"."human_id" WHERE (1 = 1) ORDER BY "humans"."id" ASC
     , query.sql);
     try std.testing.expect(query.isValid());
 }
@@ -1348,7 +1348,7 @@ test "inner and outer join" {
         .join(.outer, .family)
         .select(.{.name});
     try std.testing.expectEqualStrings(
-        \\SELECT "humans"."name" FROM "humans" INNER JOIN "cats" ON "humans"."cat_id" = "cats"."id" LEFT OUTER JOIN "families" ON "humans"."family_id" = "families"."id" WHERE (1 = 1) ORDER BY "humans"."id" ASC
+        \\SELECT "humans"."name" FROM "humans" INNER JOIN "cats" AS "cat" ON "humans"."cat_id" = "cat"."id" LEFT OUTER JOIN "families" AS "family" ON "humans"."family_id" = "family"."id" WHERE (1 = 1) ORDER BY "humans"."id" ASC
     , query.sql);
     try std.testing.expect(query.isValid());
 }
@@ -1387,7 +1387,7 @@ test "inner and outer join with select on relation columns" {
         .join(.outer, .family)
         .select(.{ .name, .{ .family = .{.id}, .cat = .{.paws} } });
     try std.testing.expectEqualStrings(
-        \\SELECT "humans"."name", "families"."id", "cats"."paws" FROM "humans" INNER JOIN "cats" ON "humans"."cat_id" = "cats"."id" LEFT OUTER JOIN "families" ON "humans"."family_id" = "families"."id" WHERE (1 = 1) ORDER BY "humans"."id" ASC
+        \\SELECT "humans"."name", "family"."id", "cat"."paws" FROM "humans" INNER JOIN "cats" AS "cat" ON "humans"."cat_id" = "cat"."id" LEFT OUTER JOIN "families" AS "family" ON "humans"."family_id" = "family"."id" WHERE (1 = 1) ORDER BY "humans"."id" ASC
     , query.sql);
     try std.testing.expect(query.isValid());
 }
@@ -1522,7 +1522,7 @@ test "complex whereclause" {
     });
     try std.testing.expect(query.isValid());
     try std.testing.expectEqualStrings(
-        \\SELECT "cats"."id", "cats"."name", "cats"."age", "cats"."favorite_sport", "cats"."status" FROM "cats" INNER JOIN "homes" ON "cats"."id" = "homes"."cat_id" WHERE ("cats"."name" = $1 OR "cats"."name" = $2 AND ("cats"."age" > $3 AND "cats"."age" < $4) AND "cats"."favorite_sport" LIKE $5 AND "cats"."favorite_sport" <> $6 AND my_sql_function(age) = $7 AND ( NOT ("cats"."age" = $8 OR "cats"."age" = $9)) AND age / paws = $10 or age * paws < $11 AND ("cats"."status" IS NULL OR "cats"."status" = ANY ($12)) AND "homes"."zip_code" = $13) ORDER BY "cats"."id" ASC
+        \\SELECT "cats"."id", "cats"."name", "cats"."age", "cats"."favorite_sport", "cats"."status" FROM "cats" INNER JOIN "homes" AS "homes" ON "cats"."id" = "homes"."cat_id" WHERE ("cats"."name" = $1 OR "cats"."name" = $2 AND ("cats"."age" > $3 AND "cats"."age" < $4) AND "cats"."favorite_sport" LIKE $5 AND "cats"."favorite_sport" <> $6 AND my_sql_function(age) = $7 AND ( NOT ("cats"."age" = $8 OR "cats"."age" = $9)) AND age / paws = $10 or age * paws < $11 AND ("cats"."status" IS NULL OR "cats"."status" = ANY ($12)) AND "homes"."zip_code" = $13) ORDER BY "cats"."id" ASC
     , query.sql);
 }
 

--- a/src/jetquery/Model.zig
+++ b/src/jetquery/Model.zig
@@ -38,20 +38,6 @@ pub fn Model(Schema: type, comptime table_name: []const u8, T: type, options: an
             return record;
         }
 
-        pub fn Relation(comptime relation_name: []const u8) type {
-            comptime {
-                for (relations) |relation| {
-                    if (std.mem.eql(u8, relation.relation_name, relation_name)) {
-                        return relation;
-                    }
-                }
-                @compileError(std.fmt.comptimePrint(
-                    "Failed matching relation `{s}` on `{s}`",
-                    .{ relation_name, name },
-                ));
-            }
-        }
-
         pub fn columns() [std.meta.fields(Definition).len]jetquery.columns.Column {
             comptime {
                 const fields = std.meta.fields(Definition);

--- a/src/jetquery/Query.zig
+++ b/src/jetquery/Query.zig
@@ -438,7 +438,7 @@ fn Statement(
         ) Statement(Adapter, .select, Schema, Model, .{
             .relations = options.relations,
             .field_infos = options.field_infos,
-            .columns = &jetquery.columns.translate(Model, options.relations, select_columns),
+            .columns = &jetquery.columns.translate(Model, options.relations, select_columns, .{}),
             .order_clauses = options.order_clauses,
             .where_clauses = options.where_clauses,
             .group_by = options.group_by,
@@ -448,7 +448,7 @@ fn Statement(
             const S = Statement(Adapter, .select, Schema, Model, .{
                 .relations = options.relations,
                 .field_infos = options.field_infos,
-                .columns = &jetquery.columns.translate(Model, options.relations, select_columns),
+                .columns = &jetquery.columns.translate(Model, options.relations, select_columns, .{}),
                 .order_clauses = options.order_clauses,
                 .where_clauses = options.where_clauses,
                 .group_by = options.group_by,
@@ -599,7 +599,7 @@ fn Statement(
             .columns = &.{},
             .order_clauses = options.order_clauses,
             .result_context = .many,
-            .distinct = &jetquery.columns.translate(Model, options.relations, args),
+            .distinct = &jetquery.columns.translate(Model, options.relations, args, .{}),
             .where_clauses = options.where_clauses,
             .group_by = options.group_by,
         }) {
@@ -609,7 +609,7 @@ fn Statement(
                 .columns = &.{},
                 .order_clauses = options.order_clauses,
                 .result_context = .many,
-                .distinct = &jetquery.columns.translate(Model, options.relations, args),
+                .distinct = &jetquery.columns.translate(Model, options.relations, args, .{}),
                 .where_clauses = options.where_clauses,
                 .group_by = options.group_by,
             });
@@ -664,7 +664,7 @@ fn Statement(
         ) Statement(Adapter, .returning, Schema, Model, .{
             .relations = options.relations,
             .field_infos = options.field_infos,
-            .columns = &jetquery.columns.translate(Model, options.relations, return_columns),
+            .columns = &jetquery.columns.translate(Model, options.relations, return_columns, .{}),
             .order_clauses = options.order_clauses,
             .group_by = options.group_by,
             .distinct = options.distinct,
@@ -673,7 +673,7 @@ fn Statement(
             const S = Statement(Adapter, .returning, Schema, Model, .{
                 .relations = options.relations,
                 .field_infos = options.field_infos,
-                .columns = &jetquery.columns.translate(Model, options.relations, return_columns),
+                .columns = &jetquery.columns.translate(Model, options.relations, return_columns, .{}),
                 .order_clauses = options.order_clauses,
                 .group_by = options.group_by,
                 .distinct = options.distinct,
@@ -814,7 +814,7 @@ fn Statement(
             .order_clauses = options.order_clauses,
             .result_context = .many,
             .where_clauses = options.where_clauses,
-            .group_by = &jetquery.columns.translate(Model, options.relations, columns),
+            .group_by = &jetquery.columns.translate(Model, options.relations, columns, .{}),
             .having_clauses = options.having_clauses,
         }) {
             const S = Statement(Adapter, .select, Schema, Model, .{
@@ -822,7 +822,7 @@ fn Statement(
                 .field_infos = options.field_infos,
                 .columns = options.columns,
                 .order_clauses = options.order_clauses,
-                .group_by = &jetquery.columns.translate(Model, options.relations, columns),
+                .group_by = &jetquery.columns.translate(Model, options.relations, columns, .{}),
                 .result_context = .many,
                 .where_clauses = options.where_clauses,
                 .having_clauses = options.having_clauses,
@@ -846,13 +846,13 @@ fn Statement(
             .group_by = options.group_by,
             .having_clauses = options.having_clauses ++
                 .{sql.Where.tree(
-                Adapter,
-                Model,
-                options.relations,
-                @TypeOf(args),
-                .where,
-                options.field_infos.len,
-            )},
+                    Adapter,
+                    Model,
+                    options.relations,
+                    @TypeOf(args),
+                    .where,
+                    options.field_infos.len,
+                )},
         }) {
             const S = Statement(Adapter, .select, Schema, Model, .{
                 .relations = options.relations,
@@ -870,13 +870,13 @@ fn Statement(
                 .group_by = options.group_by,
                 .having_clauses = options.having_clauses ++
                     .{sql.Where.tree(
-                    Adapter,
-                    Model,
-                    options.relations,
-                    @TypeOf(args),
-                    .where,
-                    options.field_infos.len,
-                )},
+                        Adapter,
+                        Model,
+                        options.relations,
+                        @TypeOf(args),
+                        .where,
+                        options.field_infos.len,
+                    )},
             });
             return self.extend(S, args, .none);
         }

--- a/src/jetquery/adapters/PostgresqlAdapter.zig
+++ b/src/jetquery/adapters/PostgresqlAdapter.zig
@@ -380,6 +380,11 @@ pub fn identifierAlloc(allocator: std.mem.Allocator, value: []const u8) ![]const
 
 /// SQL fragment used to represent a column bound to a table, e.g. `"foo"."bar"`
 pub fn columnSql(comptime column: jetquery.columns.Column) []const u8 {
+    const source = if (column.sql == null)
+        column.from orelse column.table.name
+    else
+        null;
+
     return if (column.function) |function|
         std.fmt.comptimePrint(
             \\{s}("{s}"."{s}")
@@ -391,7 +396,7 @@ pub fn columnSql(comptime column: jetquery.columns.Column) []const u8 {
                 .avg => "AVG",
                 .sum => "SUM",
             },
-            column.table.name,
+            source,
             column.name,
         })
     else if (column.sql) |sql|
@@ -399,7 +404,7 @@ pub fn columnSql(comptime column: jetquery.columns.Column) []const u8 {
     else
         std.fmt.comptimePrint(
             \\"{s}"."{s}"
-        , .{ column.table.name, column.name });
+        , .{ source, column.name });
 }
 
 /// SQL fragment used to indicate a primary key.
@@ -451,7 +456,7 @@ pub fn countSql(comptime distinct: ?[]const jetquery.columns.Column) []const u8 
             size += std.fmt.count(
                 template,
                 .{
-                    identifier(column.table.name),
+                    identifier(column.from orelse column.table.name),
                     identifier(column.name),
                     if (index + 1 < distinct_columns.len) ", " else "",
                 },
@@ -463,7 +468,7 @@ pub fn countSql(comptime distinct: ?[]const jetquery.columns.Column) []const u8 
             const column_sql = std.fmt.comptimePrint(
                 template,
                 .{
-                    identifier(column.table.name),
+                    identifier(column.from orelse column.table.name),
                     identifier(column.name),
                     if (index + 1 < distinct_columns.len) ", " else "",
                 },
@@ -508,13 +513,14 @@ pub fn outerJoinSql(
     const primary_key = options.primary_key orelse "id";
 
     return std.fmt.comptimePrint(
-        \\ LEFT OUTER JOIN "{s}" ON "{s}"."{s}" = "{s}"."{s}"
+        \\ LEFT OUTER JOIN "{s}" AS "{s}" ON "{s}"."{s}" = "{s}"."{s}"
     ,
         .{
             JoinTable.name,
+            relation_name,
             Table.name,
             foreign_key,
-            JoinTable.name,
+            relation_name,
             primary_key,
         },
     );

--- a/src/jetquery/relation.zig
+++ b/src/jetquery/relation.zig
@@ -94,6 +94,7 @@ pub fn translateRelationOptions(
         Source,
         &.{},
         if (@hasField(@TypeOf(options), "select")) options.select else .{},
+        .{ .from = @tagName(name) },
     );
 
     translated.limit = if (@hasField(@TypeOf(options), "limit"))

--- a/src/jetquery/sql.zig
+++ b/src/jetquery/sql.zig
@@ -24,7 +24,6 @@ pub const QueryContext = enum {
 };
 
 pub const OrderClause = struct {
-    // TODO: Allow ordering on relations.
     column: jetquery.columns.Column,
     direction: OrderDirection,
 };
@@ -227,6 +226,7 @@ pub fn translateOrderBy(
                         );
                         for (nested_clauses) |clause| {
                             clauses[index] = clause;
+                            clauses[index].column.from = relation.relation_name;
                             index += 1;
                         }
                         break :relations;

--- a/src/jetquery/sql/render.zig
+++ b/src/jetquery/sql/render.zig
@@ -473,10 +473,9 @@ fn renderSelectColumns(
             if (Relation.relation_type != .belongs_to) continue;
 
             for (Relation.select_columns, start..) |column, index| {
-                columns_buf_len += renderSelectColumnFromRelation(
+                columns_buf_len += renderSelectColumn(
                     Adapter,
                     column,
-                    Relation.relation_name,
                     index,
                     total_columns,
                 ).len;
@@ -504,10 +503,9 @@ fn renderSelectColumns(
             if (Relation.relation_type != .belongs_to) continue;
 
             for (Relation.select_columns, start..) |column, index| {
-                const column_tag = renderSelectColumnFromRelation(
+                const column_tag = renderSelectColumn(
                     Adapter,
                     column,
-                    Relation.relation_name,
                     index,
                     total_columns,
                 );
@@ -530,21 +528,6 @@ fn renderSelectColumn(
         return std.fmt.comptimePrint(
             " {s}{s}",
             .{ Adapter.columnSql(column), if (index + 1 < total) "," else "" },
-        );
-    }
-}
-
-fn renderSelectColumnFromRelation(
-    Adapter: type,
-    comptime column: jetquery.columns.Column,
-    comptime relation_name: []const u8,
-    comptime index: usize,
-    comptime total: usize,
-) []const u8 {
-    comptime {
-        return std.fmt.comptimePrint(
-            " {s}.{s}{s}",
-            .{ Adapter.identifier(relation_name), Adapter.identifier(column.name), if (index + 1 < total) "," else "" },
         );
     }
 }


### PR DESCRIPTION
Add `from` field to `Column`, allow specifying a source table alias which can then be used by renderers to use the appropriate alias for each column. This makes it a bit easier to make sure that all column renders use the correct alias.